### PR TITLE
Conform to og:title requirements

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -6,7 +6,7 @@
         <title>{% block title %}South Dakota Code Camp{% endblock %}</title>
         <meta name="description" content="{% block meta_description %}South Dakota Code Camp {{ event_date }} - Sioux Falls, SD. This is an event hosted by the Sioux Falls Developers Group and South Dakota .Net User Group.{% endblock %}">
         <meta property="og:image" content="{{ app.request.uriForPath('/bundles/app/images/facebook_website_share.png') }}">
-        <meta property="og:title" content="{{ block('title') }}" />
+        <meta property="og:title" content="{{ block('og_title') ? block('og_title') : block('title') }}" />
         <meta property="og:description" content="{{ block('meta_description') }}" />
         <meta property="og:url" content="{% if currentUrl is defined %}{{ currentUrl }}{% else %}{{ url(app.request.attributes.get('_route')) }}{% endif %}" />
         {% block meta_other %}{% endblock %}

--- a/app/Resources/views/default/code-of-conduct.html.twig
+++ b/app/Resources/views/default/code-of-conduct.html.twig
@@ -1,6 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block title %}Code of Conduct | {{ parent() }}{% endblock %}
+{% block og_title %}Code of Conduct{% endblock %}
 
 {% block meta_description %}South Dakota Code Camp is dedicated to a harassment-free conference experience for everyone.{% endblock %}
 

--- a/app/Resources/views/default/schedule.html.twig
+++ b/app/Resources/views/default/schedule.html.twig
@@ -1,5 +1,6 @@
 {% extends 'base.html.twig' %}
 {% block title %}{{ event_date_iso|date('Y') }} Schedule | {{ parent() }}{% endblock %}
+{% block og_title %}{{ event_date_iso|date('Y') }} Schedule{% endblock %}
 {% block meta_description %}South Dakota Code Camp {{ event_date_iso|date('Y') }} Schedule.{% endblock %}
 {% block body %}
     <style>

--- a/app/Resources/views/default/sponsor.html.twig
+++ b/app/Resources/views/default/sponsor.html.twig
@@ -1,6 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block title %}{{ event_date_iso|date('Y') }} Sponsors | {{ parent() }}{% endblock %}
+{% block og_title %}{{ event_date_iso|date('Y') }} Sponsors{% endblock %}
 
 {% block meta_description %}South Dakota Code Camp would not be possible without our sponsors. Learn more about our sponsors.{% endblock %}
 

--- a/app/Resources/views/default/venue.html.twig
+++ b/app/Resources/views/default/venue.html.twig
@@ -1,5 +1,6 @@
 {% extends 'base.html.twig' %}
 {% block title %}{{ event_date_iso|date('Y') }} Venue | {{ parent() }}{% endblock %}
+{% block og_title %}{{ event_date_iso|date('Y') }} Venue{% endblock %}
 {% block meta_description %}The next South Dakota Code Camp will be happening on {{ event_date }} at Southeast Technical Institute in Sioux Falls, SD.{% endblock %}
 {% block body %}
     <section class="page-content clearfix">

--- a/app/Resources/views/session/index.html.twig
+++ b/app/Resources/views/session/index.html.twig
@@ -1,6 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block title %}Sessions | {{ parent() }}{% endblock %}
+{% block og_title %}Sessions{% endblock %}
 
 {% block meta_description %}South Dakota Code Camp is proud to present the best developer conference in the area.{% endblock %}
 

--- a/app/Resources/views/session/show.html.twig
+++ b/app/Resources/views/session/show.html.twig
@@ -3,6 +3,7 @@
 {% set currentUrl = url('session_show_by_slug', {'id': session.id, 'slug': session.slug}) %}
 
 {% block title %}{{ session.title }} | {{ parent() }}{% endblock %}
+{% block og_title %}{{ session.title|e('html_attr') }}{% endblock %}
 
 {% block meta_description %}{{ session.abstractMarkdown|striptags|e('html_attr') }}{% endblock %}
 

--- a/app/Resources/views/speaker/index.html.twig
+++ b/app/Resources/views/speaker/index.html.twig
@@ -1,6 +1,7 @@
 {% extends "::base.html.twig" %}
 
 {% block title %}Speakers | {{ parent() }}{% endblock %}
+{% block og_title %}Speakers{% endblock %}
 
 {% block meta_description %}South Dakota Code Camp is proud to have the best conference speakers in the area.{% endblock %}
 

--- a/app/Resources/views/speaker/show.html.twig
+++ b/app/Resources/views/speaker/show.html.twig
@@ -3,6 +3,7 @@
 {% set currentUrl = url('speaker_show_by_slug', {'id': speaker.id, 'slug': speaker.slug}) %}
 
 {% block title %}{{ speaker.fullName }} | {{ parent() }}{% endblock %}
+{% block og_title %}{{ speaker.fullName|e('html_attr') }}{% endblock %}
 
 {% block meta_description %}{{ speaker.bioMarkdown|striptags|e('html_attr') }}{% endblock %}
 

--- a/app/Resources/views/speaker_submission/new.html.twig
+++ b/app/Resources/views/speaker_submission/new.html.twig
@@ -1,6 +1,7 @@
 {% extends "::base.html.twig" %}
 
 {% block title %}Call for Speakers | {{ parent() }}{% endblock %}
+{% block og_title %}Call for Speakers{% endblock %}
 
 {% block body %}
     <section class="speaker-submission interior-content clearfix">

--- a/app/Resources/views/subscriber/new.html.twig
+++ b/app/Resources/views/subscriber/new.html.twig
@@ -1,6 +1,7 @@
 {% extends "::base.html.twig" %}
 
 {% block title %}Subscribe to Updates | {{ parent() }}{% endblock %}
+{% block og_title %}Subscribe to Updates{% endblock %}
 
 {% block body %}
     <section class="speaker-submission interior-content clearfix">


### PR DESCRIPTION
According to http://ogp.me/, og:title should only include the name of
the item, and not the site name.

So, create a `og_title` block that allows setting just the name of the
item, and include that in the base template if it exists. Fall back to
`title` if `og_title` was not specified.
## Note

I don't have this running on my local machine, so I couldn't test these exact changes. I did test the `{{ block('og_title') ? block('og_title') : block('title') }}` construct in a different app to confirm that that works as expected, whether or not the `og_title` block exists or not.
